### PR TITLE
Fix deadlock in run_command in controller.py

### DIFF
--- a/clone-detector/controller.py
+++ b/clone-detector/controller.py
@@ -163,34 +163,12 @@ class ScriptController(object):
 
     def run_command(self, cmd, outFile, errFile):
         print("running new command {}".format(" ".join(cmd)))
-        fo = open(outFile, "w")
-        fe = open(errFile, "w")
-        p = subprocess.Popen(cmd,
-                             stdout=subprocess.PIPE,
-                             stderr=subprocess.PIPE,
-                             universal_newlines=True
-                             )
-        while (True):
-            returncode = p.poll()  # returns None while subprocess is running
-            outputLine = p.stdout.readline()
-            errLine = p.stderr.readline()
-            if outputLine:
-                fo.write(outputLine)
-            if errLine:
-                fe.write(errLine)
-            if returncode is not None:
-                print ("returncode is {}. ".format(returncode))
-                break
-        # read the remaining lines in the buffers
-        outputLines = p.stdout.readlines()
-        for outputLine in outputLines:
-            fo.write(outputLine)
-        errLines = p.stderr.readlines()
-        for errLine in errLines:
-            fo.write(errLine)
-        fo.close()
-        fe.close()
-        return returncode
+        with open(outFile, "w") as fo, \
+             open(errFile, "w") as fe:
+            p = subprocess.Popen(cmd, stdout=fo, stderr=fe, universal_newlines=True)
+            p.communicate()
+        return p.returncode
+
 if __name__ == '__main__':
     numnodes = 2
     if len(sys.argv) > 1:


### PR DESCRIPTION
With the previous implementation, `run_command` could deadlock.

While `stderr` stays empty, `p.stderr.readline()` will block. In the meanwhile, `stdout` output will accumulate in the pipe buffer. Once this buffer becomes full (the size is `io.DEFAULT_BUFFER_SIZE`, `8192` on my machine), the program run by `subprocess.Popen` will block when trying to output to `stdout`, resulting in a deadlock.

As all this logic was doing was buffering the process output in Python and writing it to a file, we can directly pass the file descriptor to `subprocess.Popen` and let `Popen.communicate` handle this directly.