### PR TITLE
Fix race condition when NODE_2 ends before NODE_1 starts

### DIFF
--- a/clone-detector/runnodes.sh
+++ b/clone-detector/runnodes.sh
@@ -15,6 +15,8 @@ echo $num_nodes > $rootPATH/search_metadata.txt
 
 PIDS=""
 
+rm -f "$rootPATH/nodes_completed.txt"
+
 for i in $(seq 1 1 $num_nodes)
 do
     java -Dproperties.rootDir="$rootPATH/" -Dproperties.location="$rootPATH/NODE_$i/sourcerer-cc.properties" -Dlog4j.configurationFile="$rootPATH/NODE_$i/log4j2.xml" -Xms6g -Xmx6g -XX:+UseCompressedOops -jar $rootPATH/dist/indexbased.SearchManager.jar $mode $threshold &

--- a/clone-detector/src/com/mondego/indexbased/SearchManager.java
+++ b/clone-detector/src/com/mondego/indexbased/SearchManager.java
@@ -825,12 +825,6 @@ public class SearchManager {
                 "key");
         if (SearchManager.NODE_PREFIX.equals("NODE_1")) {
             theInstance.readAndUpdateRunMetadata();
-            File completedNodeFile = new File(SearchManager.completedNodes);
-            if (completedNodeFile.exists()) {
-                logger.debug(completedNodeFile.getAbsolutePath()
-                        + "exists, deleting it.");
-                completedNodeFile.delete();
-            }
         }
     }
 


### PR DESCRIPTION
With the current implementation, there is a risk that `NODE_1` will never finish.
When running two nodes, if `NODE_2` ends before `NODE_1` reaches `initSearchEnv`, `NODE_1` will remove `nodes_completed.txt` containing `NODE_2`, and will therefore wait eternally for `NODE_2` to be added to `nodes_completed.txt`.
As `java` is being run by a bash script anyway, I think it is simpler to cleanup `node_completed.txt`in bash before running the Java process.
I understand this would not occur with a sufficient amount of input data, but this problem bit me when I was trying out the tool and it took me a while to understand what was going on, so I think this solution is safer. 